### PR TITLE
include raw data in searchEntry response

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -195,7 +195,7 @@ export default class Ldap {
 
         result.on('searchEntry', data => {
           if (canceled) return
-          if (!stream.push(data.object)) paused = true
+          if (!stream.push({ ...data.object, _raw: data.raw })) paused = true
         })
 
         result.on('page', (result, cb) => {


### PR DESCRIPTION
This adds the ability to resolve a problem if you have a `thumbnailPhoto` or `jpegPhoto` on an account. The `data.object` provides the attribute in a string format that doesn't seem to want to convert to a usable image. (If anybody knows a way to use the object version I would love to find out how)

```js
const { _raw, ...object } = await ldap.get(userDn)
// This doesn't work
// const jpegPhotoRawBuffer = Buffer.from(object.jpegPhoto)
const jpegPhotoRawBuffer = Buffer.from(_raw.jpegPhoto)
const user = {
  ...object,
  jpegPhoto: `data:image/jpeg;base64,${jpegPhotoRawBuffer.toString('base64')}`,
}
```

ldapjs/node-ldapjs#107
ldapjs/node-ldapjs#290

There may be a more elegant solution, open to other options but would be awesome to get access to the raw data for this scenario.