### PR TITLE
fixed replacing options.paged if it is true/false

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -185,9 +185,11 @@ export default class Ldap {
   }
 
   stream<T = any> (base: string, options: SearchOptions = {}, controls?: Control | Array<Control>) {
-    if (!options.paged || options.paged === true) options.paged = {}
-    if (!options.paged.pageSize) options.paged.pageSize = 200
-    options.paged.pagePause = true
+    if (options.paged === undefined) options.paged = {}
+    if (typeof (options.paged) === 'object') {
+      if (!options.paged.pageSize) options.paged.pageSize = 200
+      if (!options.paged.pagePause) options.paged.pagePause = true
+    }
     let unpause: Function | undefined
     let paused = true
     let canceled = false


### PR DESCRIPTION
In the previous code, line 188 would replace `options.paged` with `{}` if it is:
* `undefined`
* `false`
* any other value that evaluates as `false`, like `0` or `''`
* or strictly equal to `true`

and then adds the properties `pageSize` and `pagePause` to it.
This makes it impossible to disable paging by options, because any value that evaluates to `false` and would be passed to the underlying **ldapjs** is replaced by a value, that effectively turns on paging.

I think this is not expected behavior and `!options.paged` was just intended to be a check if it is undefined or not. 